### PR TITLE
Add k8s Liveness Probe to Web UI

### DIFF
--- a/airflow.all.yaml
+++ b/airflow.all.yaml
@@ -142,6 +142,12 @@ spec:
         - name: web
           containerPort: 8080
         args: ["webserver"]
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 240
+          periodSeconds: 60
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
This PR adds a liveness probe to the Kubernetes spec.
The liveness probe will regularly assert that the Web UI is up - if not, Kubernetes will restart the pod, which often can solve some of the issues with long running processes.
Please note that there's an initial delay on 240 secs (allows Airflow to have some time for booting up). After the initial period the liveness probe will poll `/` on port `8080` every minute. 

Fixes: #10