### PR TITLE
Fixed typo that stopped 'make helm-check' from working.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ helm-install:
 	             $(CHART_LOCATION)
 
 helm-check:
-	helm install --dry_run \
+	helm install --dry-run \
 	            $(CHART_LOCATION) \
 	             --version=v0.1.0 \
 	             --name=$(HELM_APPLICATION_NAME) \


### PR DESCRIPTION
Mini PR that fixes the 'make helm-check' command for dry running the helm install.