### PR TITLE
Rename celery_result_backend to result_backend

### DIFF
--- a/airflow/myvalue-with-airflowcfg-configmap.yaml
+++ b/airflow/myvalue-with-airflowcfg-configmap.yaml
@@ -102,7 +102,7 @@ airflow:
     broker_url = amqp://{{ RABBITMQ_CREDS }}@{{ RABBITMQ_HOST }}:5672/airflow
 
     # Another key Celery setting
-    celery_result_backend = amqp://{{ RABBITMQ_CREDS }}@{{ RABBITMQ_HOST }}:5672/airflow
+    result_backend = amqp://{{ RABBITMQ_CREDS }}@{{ RABBITMQ_HOST }}:5672/airflow
 
     # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
     # it `airflow flower`. This defines the port that Celery Flower runs on

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -147,7 +147,7 @@ worker_log_server_port = 8793
 broker_url = amqp://{{ RABBITMQ_CREDS }}@{{ RABBITMQ_HOST }}:5672/airflow
 
 # Another key Celery setting
-celery_result_backend = amqp://{{ RABBITMQ_CREDS }}@{{ RABBITMQ_HOST }}:5672/airflow
+result_backend = amqp://{{ RABBITMQ_CREDS }}@{{ RABBITMQ_HOST }}:5672/airflow
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it `airflow flower`. This defines the port that Celery Flower runs on


### PR DESCRIPTION
After changes here [0] when running airflow with parameter
`celery_result_backend` scheduler and worker processes will crash
trying to connect to MySQL host, which is default host for celery.
This error is weird especially in case when celery is configured to
connect to PostgreSQL or different backend.
This patch will fix this issue.

[0] - https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#celery-config