### PR TITLE
Run scheduler in a loop

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -75,4 +75,20 @@ if [ ! -z $GIT_SYNC_REPO ]; then
     $AIRFLOW_HOME/git-sync --dest $AIRFLOW_HOME/dags --force &
 fi
 
-$CMD "$@"
+# Run scheduler in a loop
+case "$1" in
+    scheduler)
+        while true; do
+            echo "Starting scheduler run at "$(date)
+            $CMD "$@"
+            exit_code=$(echo $?)
+            if [ $exit_code != 0 ]; then
+                echo "Scheduler had a fatal error. Exit code: "$exit_code
+                exit 1
+            fi
+        done
+        ;;
+    *)
+        $CMD "$@"
+        ;;
+


### PR DESCRIPTION
I ran into the same issue discussed in #20 (and hinted in #27) and decided to roll with the solution initially proposed by @jdavidheiser to run the scheduler in a while loop and break if it returns a bad error code. Here's the same code I'm using in my entrypoint script to address the issue.